### PR TITLE
Add support for darwin/clang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        perl-version: ['5.8', '5.10', '5.14', '5.20', '5.28', '5.32']
+        perl-version: ['5.10', '5.14', '5.20', '5.28', '5.32']
         include:
           - perl-version: '5.30'
             os: ubuntu-latest
@@ -22,9 +22,13 @@ jobs:
     container: perl:${{ matrix.perl-version }}
     steps:
       - uses: actions/checkout@v2
-      - run: cpanm Devel::CheckLib ExtUtils::MakeMaker
+      - run: cpanm -n ExtUtils::MakeMaker Alien::Build
       - run: cpanm -n --with-recommends --installdeps .
       - run: perl -V
+      - name: Build
+        run: |
+          perl Makefile.PL
+          make
       - name: Run release tests # before others as may install useful stuff
         if: ${{ matrix.release-test }}
         env:
@@ -32,17 +36,19 @@ jobs:
         run: |
           apt-get update && apt-get install -y libfile-copy-recursive-perl
           cpanm -n --installdeps --with-develop .
-          prove -lr xt
+          prove -brj4 xt
       - name: Run tests (no coverage)
         if: ${{ !matrix.coverage }}
-        run: prove -l -j4 t
+        run: prove -brj4 t
       - name: Run tests (with coverage)
         if: ${{ matrix.coverage }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TESTING: 1
         run: |
           cpanm -n Devel::Cover::Report::Coveralls
-          HARNESS_OPTIONS='j4' cover -test -report Coveralls
+          HARNESS_PERL_SWITCHES='-MDevel::Cover=-delete,-ignore,Alien/OpenMP/Install/Files\\.pm$' prove -brj4 t xt
+          cover -report Coveralls
   non-linux:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -59,4 +65,24 @@ jobs:
           args: -n --installdeps .
       - run: perl -V
       - name: Run tests
-        run: prove -l -j4 t
+        run: |
+          perl Makefile.PL
+          make
+          prove -brj4 t
+  darwin:
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Perl
+        run: brew install perl libomp
+      - name: perl -V
+        run: perl -V
+      - name: Install Dependencies
+        run: |
+          curl -L https://cpanmin.us | tee cpanm | perl - -n ExtUtils::MakeMaker Alien::Build Inline Inline::C
+          perl ./cpanm -n --installdeps .
+      - name: Run Tests
+        run: |
+          perl Makefile.PL
+          make
+          prove -brv t xt

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.old
 *.swp
 /*.tar.gz
+/_alien/
 /blib/
 /cover_db
 /inc/

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -54,3 +54,4 @@
 ^xt/
 ^nytprof\.out
 ^nytprof/
+^\.proverc$

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,40 +1,30 @@
 use strict;
 use warnings;
 use ExtUtils::MakeMaker;
-use Devel::CheckLib;
-use lib q{lib};
 use Config ();
+use Alien::Build::MM;
 
-# all supported compilers must be registered in @SUPPORTED_CCNAMES
-my @SUPPORTED_CCNAMES = (qw/gcc/);
-
-_assert_supported_environment( $Config::Config{ccname} );
-
+my $abmm = Alien::Build::MM->new;
 my $repo = 'oodler577/p5-Alien-OpenMP';
-(my $file = (my $pkg = 'Alien::OpenMP')) =~ s#::#/#g;
-$file = "lib/$file.pm";
-WriteMakefile(
+(my $dist = (my $pkg = 'Alien::OpenMP')) =~ s#::#-#g;
+WriteMakefile($abmm->mm_args(
     NAME               => $pkg,
-    VERSION_FROM       => $file,
-    ABSTRACT_FROM      => $file,
+    DISTNAME           => $dist,
     AUTHOR             => q{OODLER 577 <oodler@cpan.org>},
     LICENSE            => 'artistic_2',
     MIN_PERL_VERSION   => '5.008009',
     CONFIGURE_REQUIRES => {
         'ExtUtils::MakeMaker' => 0,
-        'Devel::CheckLib'     => 0,
     },
     BUILD_REQUIRES => {
         'ExtUtils::MakeMaker' => 0,
-        'Devel::CheckLib'     => 0,
     },
     TEST_REQUIRES => {
         'Test::More'      => 0,
-        'Devel::CheckLib' => 0,
     },
     PREREQ_PM => {
         'Test::More' => 0,
-        'Devel::CheckLib' => 0,
+        'Alien::Base' => 0,
     },
     META_MERGE => {
         "meta-spec"    => { version => 2 },
@@ -59,8 +49,7 @@ WriteMakefile(
                     'Test::Pod'           => '1.00',
                     'Pod::Markdown'       => 0,
                     'Inline::C'           => 0,
-                    'Devel::CheckLib'     => 0,
-		    'Dist::Zilla'         => 0,
+                    'Dist::Zilla'         => 0,
                 },
             },
             test => {
@@ -70,49 +59,8 @@ WriteMakefile(
             },
         },
     },
-);
+));
 
-# OpenMP specific assertion that leverages Devel::CheckLib and
-# information that should be provided for the compiler being test
-# but the Alien::OpenMP module itself
-sub _assert_supported_environment {
-    my $ccname = shift;
-
-    # fail out the boat for macos since clang masks as gcc and needs
-    # to be handled as a new compiler type integration
-    die qq{OS unsupported\n} if $^O eq q{darwin};
-
-    if ( grep { $_ =~ /$Config::Config{ccname}/ } @SUPPORTED_CCNAMES ) {
-        require Alien::OpenMP;
-        my $ao = bless {}, q{Alien::OpenMP};
-        local $/ = undef;    # slurp mode for main() body in __DATA__
-        check_lib_or_exit(
-            lib      => $ao->_check_libs,
-            header   => $ao->_check_headers,
-            ccflags  => $ao->cflags,
-            ldflags  => $ao->lddlflags,
-            function => <DATA>,
-        );
-        return;
-    }
-    die qq{OS unsupported\n};
+sub MY::postamble {
+  $abmm->mm_postamble;
 }
-
-__DATA__
-/*
-   start of main() implied via use of Devel::CheckLib
-   the following should only pass if running in a properly
-   supported OpenMP environment; modifications to this should
-   ensure it's not just testing for a successful compile and link
-*/
-  // done before thread fork
-  omp_set_num_threads(3);
-  int ans = 42;
-  // thread section follows
-  #pragma omp parallel
-    #pragma omp master
-      ans = omp_get_num_threads(); // done in parallel section, but only by master thread (0)
-  if (3 == ans)
-    return 0;   // good
-  return 1;     // bad
-// end of implicit main

--- a/alienfile
+++ b/alienfile
@@ -1,0 +1,58 @@
+# -*- mode: perl -*-
+use alienfile;
+use lib q{lib};
+use Alien::OpenMP::configure;
+no lib q{lib};
+
+configure {
+  if ($^O eq 'darwin') {
+    requires 'File::Which' => '1.27';
+    requires 'Path::Tiny'  => '0.053';
+  }
+  if (!Alien::OpenMP::configure->is_known) {
+    Alien::OpenMP::configure->unsupported(__PACKAGE__);
+    exit;
+  }
+};
+
+plugin 'Probe::CBuilder' => (
+  cflags  => Alien::OpenMP::configure->cflags,
+  lang    => 'C',
+  libs    => Alien::OpenMP::configure->libs,
+  options => {quiet => 0},
+  program => join("\n" => <DATA>),
+);
+
+after probe => sub {
+  # only reached on success AFAICT
+  shift->install_prop->{'alien_openmp_compiler_has_openmp'} = 1;
+};
+
+share {
+  before download => sub {
+    my $build = shift;
+    Alien::OpenMP::configure->unsupported($build);
+    exit;
+  };
+};
+
+
+__DATA__
+/*
+   the following should only pass if running in a properly
+   supported OpenMP environment; modifications to this should
+   ensure it's not just testing for a successful compile and link
+*/
+// done before thread fork
+#include <omp.h>
+int main () {
+  omp_set_num_threads(3);
+  int ans = 42;
+// thread section follows
+#pragma omp parallel
+#pragma omp master
+  ans = omp_get_num_threads(); // done in parallel section, but only by master thread (0)
+  if (3 == ans)
+    return 0;   // good
+  return 1;     // bad
+} // end of implicit main

--- a/lib/Alien/OpenMP.pm
+++ b/lib/Alien/OpenMP.pm
@@ -1,80 +1,24 @@
 package Alien::OpenMP;
 
-use strict;
-use warnings;
+use parent 'Alien::Base';
 use Config ();
 
 our $VERSION = '0.003002';
 
-# set as package variable since %Config::Config is read only, (per docs and in practice)
-our $CCNAME = $Config::Config{ccname};
-
-# per-compiler meta data, each supported compiler will require an entry
-
-our $omp_flags = {
-    # used by ccflags, lddlflags
-    gcc => '-fopenmp',
-};
-
-our $omp_check_libs = {
-    # used by _check_libs, intended for use by Devel::CheckLib
-    gcc => [qw/gomp/],
-};
-
-our $omp_check_headers = {
-    # used by _check_headers, intended for use by Devel::CheckLib
-    gcc => [qw/omp.h/],
-};
-
 # "public" Alien::Base method implementations
-
-sub cflags {
-    my $cn = $CCNAME;
-    _assert_os($omp_flags, $cn);
-    return $omp_flags->{$cn};
-}
 
 # we can reuse cflags for gcc/gomp; hopefully this will
 # remain the case for all supported compilers
-
-sub lddlflags {
-    my $cn = $CCNAME;
-    _assert_os($omp_flags, $cn);
-    return $omp_flags->{$cn};
-}
+sub lddlflags { shift->libs }
 
 # Inline related methods
 
 sub Inline {
   my ($self, $lang) = @_;
   return {
-    CCFLAGS     => cflags(),
-    LDDLFLAGS   => join( q{ }, $Config::Config{lddlflags}, lddlflags() ),
+    CCFLAGS     => $self->cflags(),
+    LDDLFLAGS   => join( q{ }, $Config::Config{lddlflags}, $self->lddlflags() ),
   };
-}
-
-# "private" internal helper subs
-
-sub _assert_os {
-    my ($omp, $cn) = @_;
-    # OpenMP pragmas live behind source code comments
-    if ( not defined $omp->{$cn} ) {
-      # dies the same way as ExtUtils::MakeMaker::os_unsupported()
-      die qq{OS unsupported\n};
-    }
-    return;
-}
-
-sub _check_libs {
-    my $cn = $CCNAME;
-    _assert_os($omp_check_libs, $cn);
-    return $omp_check_libs->{$cn};
-}
-
-sub _check_headers {
-    my $cn = $CCNAME;
-    _assert_os($omp_check_headers, $cn);
-    return $omp_check_headers->{$cn};
 }
 
 1;
@@ -123,6 +67,13 @@ At this time, the following compilers are supported:
 C<-fopenmp> enables OpenMP support in via compiler and linker:
 
     gcc -fopenmp ./my-openmp.c -o my-openmp.x
+
+=item C<clang> EXPERIMENTAL
+
+C<-fopenmp> enables OpenMP support via compiler and linker in recent
+versions of C<clang>. MacOS shipped versions are missing the library
+which needs installing either with L<Homebrew|https://brew.sh> or
+L<Macports|https://www.macports.org>.
 
 =back
 
@@ -178,7 +129,8 @@ L<Inline>). This method is not called directly, but used when compiling
 OpenMP programs with C<Inline::C>:
 
     use Alien::OpenMP; use Inline (
-        C           => 'DATA', with        => qw/Alien::OpenMP/,
+        C           => 'DATA',
+        with        => qw/Alien::OpenMP/,
     );
 
 The nice, compact form above replaces this mess:
@@ -188,22 +140,6 @@ The nice, compact form above replaces this mess:
         lddlflags   => join( q{ }, $Config::Config{lddlflags},
         Alien::OpenMP::lddlflags() ),
     );
-
-=item C<_check_libs>
-
-Internal method.
-
-Returns an array reference of libraries, e.g., C<gomp> for C<gcc>. It is
-meant specifically as an internal method to support L<Devel::CheckLib>
-in this module's C<Makefile.PL>.
-
-=item C<_check_headers>
-
-Internal method.
-
-Returns an array reference of header files, e.g., C<omp.h> for C<gcc>. It
-is meant specifically as an internal method to support L<Devel::CheckLib>
-in this module's C<Makefile.PL>.
 
 =back
 

--- a/lib/Alien/OpenMP/configure.pm
+++ b/lib/Alien/OpenMP/configure.pm
@@ -1,0 +1,149 @@
+package Alien::OpenMP::configure;
+use strict;
+use warnings;
+use Config;
+
+our $CCNAME = $ENV{CC} || $Config::Config{ccname};
+our $OS     = $^O;
+
+my $checked   = 0;
+my $supported = {
+  gcc   => {cflags => ['-fopenmp'],            libs => ['-fopenmp']},
+  clang => {cflags => ['-Xclang', '-fopenmp'], libs => ['-lomp']},      # this could be -Xpreprocessor
+};
+
+sub cflags {
+  shift->_update_supported;
+  return join ' ', @{$supported->{$OS}{cflags} || $supported->{$CCNAME}{cflags} || []};
+}
+
+sub is_known {
+  shift->_update_supported;
+  return !!(exists($supported->{$OS}) || exists($supported->{$CCNAME}));
+}
+
+sub lddlflags { __PACKAGE__->libs }
+
+sub libs {
+  shift->_update_supported;
+  return join ' ', @{$supported->{$OS}{libs} || $supported->{$CCNAME}{libs} || []};
+}
+
+sub unsupported {
+  my ($self, $build) = (shift, shift);
+
+  # build an array of messages
+  my @msg = ("This version of $CCNAME does not support OpenMP");
+  if ($CCNAME eq 'gcc' and $OS ne 'darwin') {
+    push @msg, "This could be a bug, please record and issue https://github.com/oodler577/p5-Alien-OpenMP/issues";
+  }
+
+  if ($OS eq 'darwin') {
+    push @msg, "Support can be enabled by using Homebrew or Macports (https://clang-omp.github.io)";
+    push @msg, "    brew install libomp (Homebrew https://brew.sh)";
+    push @msg, "    port install libomp (Macports https://www.macports.org)";
+  }
+
+  # report messages using appropriate method
+  if (ref($build)) {
+    return if $build->install_prop->{alien_openmp_compiler_has_openmp};
+    unshift @msg, "phase = @{[$build->meta->{phase}]}";
+    $build->log($_) for @msg;
+  }
+  elsif ($build && (my $log = $build->can('log'))) {
+    unshift @msg, "phase = @{[$build->meta->{phase}]}";
+    $log->($_) for @msg;
+  }
+  else {
+    warn join q{>}, __PACKAGE__, " $_\n" for @msg;
+  }
+  print "OS Unsupported\n";
+}
+
+# test support only
+sub _reset { $checked = 0; }
+
+sub _update_supported {
+  return if $checked;
+  if ($OS eq 'darwin') {
+    require File::Which;
+    require Path::Tiny;
+
+    # The issue here is that ccname=gcc and cc=cc as an interface to clang
+    $supported->{darwin} = {cflags => ['-Xclang', '-fopenmp'], libs => ['-lomp'],};
+    if (my $mp = File::Which::which('port')) {
+
+      # macports /opt/local/bin/port
+      my $mp_prefix = Path::Tiny->new($mp)->parent->parent;
+      push @{$supported->{darwin}{cflags}}, "-I$mp_prefix/include/libomp";
+      unshift @{$supported->{darwin}{libs}}, "-L$mp_prefix/lib/libomp";
+    }
+    else {
+      # homebrew has the headers and library in /usr/local
+      push @{$supported->{darwin}{cflags}}, "-I/usr/local/include";
+      unshift @{$supported->{darwin}{libs}}, "-L/usr/local/lib";
+    }
+  }
+  $checked++;
+}
+
+1;
+
+=encoding utf8
+
+=head1 NAME
+
+Alien::OpenMP::configure - Install time configuration helper
+
+=head1 SYNOPSIS
+
+  # alienfile
+  use Alien::OpenMP::configure;
+
+  if (!Alien::OpenMP::configure->is_known) {
+    Alien::OpenMP::configure->unsupported(__PACKAGE__);
+    exit;
+  }
+
+  plugin 'Probe::CBuilder' => (
+    cflags  => Alien::OpenMP::configure->cflags,
+    libs    => Alien::OpenMP::configure->libs,
+    ...
+  );
+
+=head1 DESCRIPTION
+
+L<Alien::OpenMP::configure> is storage for the compiler flags required for multiple compilers on multiple systems and
+an attempt to intelligently support them.
+
+This module is designed to be used by the L<Alien::OpenMP::configure> authors and contributors, rather than end users.
+
+=head1 METHODS
+
+L<Alien::OpenMP::configure> implements the following methods.
+
+=head2 cflags
+
+Obtain the compiler flags for the compiler and architecture suitable for passing as C<cflags> to
+L<Alien::Build::Plugin::Probe::CBuilder>.
+
+=head2 is_known
+
+Return a Boolean to indicate whether the compiler is known to this module.
+
+=head2 lddlflags
+
+A synonym for L</"libs">.
+
+=head2 libs
+
+Obtain the compiler flags for the compiler and architecture suitable for passing as C<libs> to
+L<Alien::Build::Plugin::Probe::CBuilder>.
+
+=head2 unsupported
+
+Report using L<Alien::Build::Log> or L<warn|https://metacpan.org/pod/perlfunc#warn-LIST> that the compiler/architecture
+combination is unsupported and provide minimal notes on any solutions. There is little to no guarding of the actual
+state of support in this function.
+
+=cut

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -1,71 +1,17 @@
 use strict;
 use warnings;
-
 use Test::More;
-use FindBin qw/$Bin/;
-use lib qq{$Bin/../lib};
+use Test::Alien;
+use Alien::OpenMP;
 
-use_ok( q{Alien::OpenMP}, q{Can load Alien::OpenMP} );
+subtest 'syntax and interface' => sub {
+  alien_ok 'Alien::OpenMP', 'public interface check for Alien::Base'; 
+  is +Alien::OpenMP->install_type, 'system', 'no share install is possible';
+};
 
-# no actual constructor exists
-my $snoo = bless {}, q{Alien::OpenMP};
-
-can_ok( $snoo, qw/cflags lddlflags/ );
-
-# dev note 1: add a new lexically scoped blockfor each
-# 'ccname' that gets added to Alien::OpenMP; please
-# don't get fancy and create a loop
-
-# dev note 2: this test is not dependent on the
-# environment, see the use of a local'd version of
-# %Config::Config below for a hint on how to properly
-# add additional tests as compiler support is added to
-# this module.
-
-GCC:
-{
-    my $omp_flag = q{-fopenmp};
-    local $Alien::OpenMP::CCNAME = q{gcc};
-    is $snoo->cflags,    $omp_flag, q{Found expected OpenMP compiler switch for gcc.};
-    is $snoo->lddlflags, $omp_flag, q{Found expected OpenMP linker switch for gcc.};
-    is $snoo->lddlflags, $snoo->cflags, q{cflags and lddlflags are the same.};
-    is_deeply $snoo->_check_libs, [qw/gomp/], q{_check_libs returns as expected};
-    is_deeply $snoo->_check_headers, [qw/omp.h/], q{_check_headers returns as expected};
-}
-
-UNSUPPORTED:
-{
-    local $Alien::OpenMP::CCNAME = q{unsupported xyz};
-    local $@;
-    # force exception for cflags
-    my $ok = eval {
-      $snoo->cflags;
-    };
-    chomp $@;
-    is $@, q{OS unsupported}, q{clfags - OS Unsupported thrown when expected};
-    # reset and force exception for lddlflags
-    $@ = undef;
-    $ok = eval {
-      $snoo->lddlflags;
-    };
-    chomp $@;
-    is $@, q{OS unsupported}, q{lddlflags - OS Unsupported thrown when expected};
-    $@ = undef;
-    $ok = eval {
-      $snoo->_check_libs;
-    };
-    chomp $@;
-    is $@, q{OS unsupported}, q{_check_libs - OS Unsupported thrown when expected};
-    $@ = undef;
-    $ok = eval {
-      $snoo->_check_headers;
-    };
-    chomp $@;
-    is $@, q{OS unsupported}, q{_check_headers- OS Unsupported thrown when expected};
-}
+subtest 'has options' => sub {
+  like +Alien::OpenMP->cflags,    qr{-fopenmp},           q{Found expected OpenMP compiler switch for gcc/clang.};
+  like +Alien::OpenMP->lddlflags, qr{(?:-lomp|-fopenmp)}, q{Found expected OpenMP linker switch for gcc/clang.};
+};
 
 done_testing;
-
-exit;
-
-__END__

--- a/xt/configure.t
+++ b/xt/configure.t
@@ -1,0 +1,102 @@
+BEGIN { $ENV{CC} = 'xyz-cc' }
+use strict;
+use warnings;
+use Test::More;
+use Test::Alien;
+use Alien::OpenMP::configure;
+use Path::Tiny;
+use Capture::Tiny qw(capture);
+
+plan skip_all => "Author tests not required for installation" unless !!$ENV{RELEASE_TESTING};
+
+# Author test for the configure module.
+
+# dev note 1: add a new lexically scoped blockfor each
+# 'ccname' that gets added to Alien::OpenMP; please
+# don't get fancy and create a loop.
+
+# dev note 2: this test is not dependent on the
+# environment, see the use of a local'd version of
+# %Config::Config below for a hint on how to properly
+# add additional tests as compiler support is added to
+# this module.
+
+subtest 'CC environment variable' => sub {
+  local $Alien::OpenMP::configure::OS = 'linux';
+  Alien::OpenMP::configure->_reset;
+  is $Alien::OpenMP::configure::CCNAME, 'xyz-cc', 'esoteric compiler name';
+  ok !Alien::OpenMP::configure->is_known, q{not known};
+};
+
+subtest 'gcc' => sub {
+  local $Alien::OpenMP::configure::CCNAME = 'gcc';
+  local $Alien::OpenMP::configure::OS     = 'linux';
+  my $omp_flag = q{-fopenmp};
+  Alien::OpenMP::configure->_reset;
+  is +Alien::OpenMP::configure->is_known,  1, q{known};
+  is +Alien::OpenMP::configure->cflags,    $omp_flag, q{Found expected OpenMP compiler switch for gcc.};
+  is +Alien::OpenMP::configure->lddlflags, $omp_flag, q{Found expected OpenMP linker switch for gcc.};
+};
+
+subtest 'darwin clang/gcc homebrew' => sub {
+  local $Alien::OpenMP::configure::CCNAME = 'gcc';
+  local $Alien::OpenMP::configure::OS     = 'darwin';
+  local $ENV{PATH}                        = "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin";
+  Alien::OpenMP::configure->_reset;
+  is +Alien::OpenMP::configure->is_known, 1,                    q{known};
+  like +Alien::OpenMP::configure->cflags, qr{-Xclang -fopenmp}, q{Found expected OpenMP compiler switch for gcc/clang.};
+  like +Alien::OpenMP::configure->lddlflags, qr{-lomp},         q{Found expected OpenMP linker switch for gcc/clang.};
+  like +Alien::OpenMP::configure->cflags,    qr{-I/usr/local/include}, q{Found path to include headers};
+};
+
+subtest 'darwin clang/gcc macports' => sub {
+  local $Alien::OpenMP::configure::CCNAME = 'gcc';
+  local $Alien::OpenMP::configure::OS     = 'darwin';
+  local $ENV{PATH}                        = "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin";
+
+  # create a mock port executable
+  my $tempdir = Path::Tiny->tempdir();
+  my $port    = $tempdir->child('bin', 'port');
+  $port->parent->mkpath;
+  $port->spew("#!/bin/bash");
+  $port->chmod(0755);
+  $ENV{PATH} .= ":$tempdir/bin";
+  Alien::OpenMP::configure->_reset;
+  is +Alien::OpenMP::configure->is_known, 1,                    q{known};
+  like +Alien::OpenMP::configure->cflags, qr{-Xclang -fopenmp}, q{Found expected OpenMP compiler switch for gcc/clang.};
+  like +Alien::OpenMP::configure->lddlflags, qr{-lomp},         q{Found expected OpenMP linker switch for gcc/clang.};
+  like +Alien::OpenMP::configure->cflags,    qr{-I$tempdir/include/libomp}, q{Found path to include headers};
+  like +Alien::OpenMP::configure->libs,      qr{-L$tempdir/lib/libomp},     q{Found path to library};
+};
+
+subtest 'unknown and therefore unsupported' => sub {
+  local $Alien::OpenMP::configure::CCNAME = q{unsupported xyz};
+  local $Alien::OpenMP::configure::OS     = q{foobar-os};
+  Alien::OpenMP::configure->_reset;
+
+  ok !Alien::OpenMP::configure->is_known, 'not known AKA unsupported';
+  is +Alien::OpenMP::configure->cflags, q{}, 'empty string';
+  is +Alien::OpenMP::configure->libs,   q{}, 'empty string';
+
+  my ($stdout, $stderr, @result) = capture { Alien::OpenMP::configure->unsupported; 1 };
+  is_deeply \@result, [1], 'no errors';
+  like $stdout, qr{^OS Unsupported},                                         'Message for ExtUtils::MakeMaker';
+  like $stderr, qr{This version of unsupported xyz does not support OpenMP}, 'unsupported compiler name';
+};
+
+subtest 'darwin, missing dependencies' => sub {
+  local $Alien::OpenMP::configure::CCNAME = q{clang};
+  local $Alien::OpenMP::configure::OS     = q{darwin};
+  local $ENV{PATH}                        = "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin";
+  Alien::OpenMP::configure->_reset;
+  ok +Alien::OpenMP::configure->is_known, 'known';
+
+  my ($stdout, $stderr, @result) = capture { Alien::OpenMP::configure->unsupported; 1 };
+  is_deeply \@result, [1], 'no errors';
+  like $stdout, qr{^OS Unsupported},                                      'Message for ExtUtils::MakeMaker';
+  like $stderr, qr{This version of clang does not support OpenMP},        'clang missing openmp support';
+  like $stderr, qr{Support can be enabled by using Homebrew or Macports}, 'unsupported compiler name';
+};
+
+
+done_testing;

--- a/xt/inline-c-with.t
+++ b/xt/inline-c-with.t
@@ -1,19 +1,24 @@
+BEGIN {
+  # https://bugs.llvm.org/show_bug.cgi?id=50579
+  $ENV{LIBOMP_USE_HIDDEN_HELPER_TASK} = $ENV{LIBOMP_NUM_HIDDEN_HELPER_THREADS} = 0 if $^O eq 'darwin';
+}
 use strict;
 use warnings;
-use Test::More tests => 9;
-
-use FindBin qw/$Bin/;
-use lib qq{$Bin/../lib};
-
+use Test::More;
 use Alien::OpenMP;
+use File::Temp ();
 use Inline (
     C           => 'DATA',
     with        => qw/Alien::OpenMP/,
+    directory   => (my $tmp = File::Temp::tempdir()),
+    build_noisy => !!$ENV{HARNESS_IS_VERBOSE}
 );
 
 for my $num_threads (qw/1 2 4 8 16 32 64 128 256/) {
     is test($num_threads), $num_threads, qq{Ensuring compiled OpenMP program works as expected. Threads = $num_threads};
 }
+
+done_testing;
 
 __DATA__
 

--- a/xt/pod-coverage.t
+++ b/xt/pod-coverage.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Test::More;
 
-# only invoked currently on Githun CI
+# only invoked currently on Github CI
 unless ( $ENV{RELEASE_TESTING} ) {
     plan( skip_all => "Author tests not required for installation" );
 }
@@ -20,4 +20,4 @@ eval "use Pod::Coverage $min_pc";
 plan skip_all => "Pod::Coverage $min_pc required for testing POD coverage"
     if $@;
 
-all_pod_coverage_ok({ trustme => [qr/^(final|got)/], coverage_class => 'Pod::Coverage::CountParents' });
+all_pod_coverage_ok({ trustme => [qr/^(final|got|Inline)/], coverage_class => 'Pod::Coverage::CountParents' });


### PR DESCRIPTION
This pull request adds support for clang on macOS. This involves a switch to a more `Alien::Build` style, including an `alienfile`, compiling at `probe` time with `Probe::CBuilder`, and only supporting system installs. AB manages the runtime settings, making `Alien::OpenMP` more simple. The other side of this is that there's a new module to store the possible scenarios and a dependency on `Alien::Build`.

Thanks for considering this request.