### PR TITLE
Add openmp_version method

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -1,5 +1,6 @@
 # -*- mode: perl -*-
 use alienfile;
+use Alien::Build::CommandSequence;
 use lib q{lib};
 use Alien::OpenMP::configure;
 no lib q{lib};
@@ -15,6 +16,8 @@ configure {
   }
 };
 
+meta->interpolator->replace_helper(cc => sub { $Alien::OpenMP::configure::CCNAME });
+
 plugin 'Probe::CBuilder' => (
   lang         => 'C',
   cflags       => Alien::OpenMP::configure->cflags,
@@ -28,6 +31,16 @@ after probe => sub {
   my $build = shift;
   $build->install_prop->{'alien_openmp_compiler_has_openmp'} = 1;
   $build->runtime_prop->{auto_include}                       = Alien::OpenMP::configure->auto_include;
+  my $seq = Alien::Build::CommandSequence->new([
+    join(' ', '%{cc}', '-dM', Alien::OpenMP::configure->cflags, '-E', '-', '<', '%{devnull}'),
+    sub {
+      my ($build, $args) = @_;
+      my @props   = qw{openmp_version version};
+      my $runtime = Alien::OpenMP::configure->version_from_preprocessor($args->{out});
+      @{$build->runtime_prop}{@props} = @$runtime{@props};
+    }
+  ]);
+  $seq->execute($build);
 };
 
 share {

--- a/lib/Alien/OpenMP.pm
+++ b/lib/Alien/OpenMP.pm
@@ -12,6 +12,8 @@ our $VERSION = '0.003007';
 # remain the case for all supported compilers
 sub lddlflags { shift->libs }
 
+sub openmp_version { shift->runtime_prop->{openmp_version} }
+
 # Inline related methods
 
 sub Inline {
@@ -126,6 +128,19 @@ Returns the flag used by the linker to enable OpenMP. This is usually
 the same as what is returned by C<cflags>.
 
 Example, GCC uses, C<-fopenmp>, for this as well.
+
+=item C<openmp_version>
+
+Returns the version of OpenMP provided by the compiler. The value returned
+is the value of the C<#define _OPENMP>.
+
+For a decimal version consider using L</"version">.
+
+=item C<version>
+
+Return the version of OpenMP provided by the compiler in decimal form. The
+table used is derived from
+L<https://github.com/jeffhammond/HPCInfo/blob/master/docs/Preprocessor-Macros.md>.
 
 =item C<Inline>
 

--- a/lib/Alien/OpenMP/configure.pm
+++ b/lib/Alien/OpenMP/configure.pm
@@ -73,6 +73,22 @@ sub unsupported {
   print "OS Unsupported\n";
 }
 
+sub version_from_preprocessor {
+  my ($self, $lines) = @_;
+  my $define_re = qr/^(?:.*_OPENMP\s)?([0-9]+)$/;
+  my %runtime;
+  ($runtime{openmp_version}) = map { (my $v = $_) =~ s/$define_re/$1/; $v } grep /$define_re/, split m{$/}, $lines;
+  $runtime{version} = _openmp_defined($runtime{openmp_version});
+  return \%runtime;
+}
+
+sub _openmp_defined {
+  my $define = pop;
+  # From https://github.com/jeffhammond/HPCInfo/blob/master/docs/Preprocessor-Macros.md
+  my $versions = {200505 => '2.5', 200805 => '3.0', 201107 => '3.1', 201307 => '4.0', 201511 => '4.5', 201811 => '5.0'};
+  return $versions->{$define || ''} || 'unknown';
+}
+
 # test support only
 sub _reset { $checked = 0; }
 
@@ -158,5 +174,10 @@ L<Alien::Build::Plugin::Probe::CBuilder>.
 Report using L<Alien::Build::Log> or L<warn|https://metacpan.org/pod/perlfunc#warn-LIST> that the compiler/architecture
 combination is unsupported and provide minimal notes on any solutions. There is little to no guarding of the actual
 state of support in this function.
+
+=head2 version_from_preprocessor
+
+Parse the output from the C preprocessor, filtering for the C<#define _OPENMP> to populate a hash with both the value
+and the equivalent decimal version. The keys of the hash are C<openmp_version> and C<version>.
 
 =cut

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -14,4 +14,8 @@ subtest 'has options' => sub {
   like +Alien::OpenMP->lddlflags, qr{(?:-lomp|-fopenmp)}, q{Found expected OpenMP linker switch for gcc/clang.};
 };
 
+subtest 'OpenMP version' => sub {
+  like +Alien::OpenMP->openmp_version, qr{^[0-9]{6}$},       q{looks like a dated version};
+  like +Alien::OpenMP->version,        qr{^[0-9]+\.[0-9]+$}, q{looks like a decimal version};
+};
 done_testing;

--- a/t/03-configure.t
+++ b/t/03-configure.t
@@ -86,5 +86,30 @@ subtest 'darwin, missing dependencies' => sub {
   like $stderr, qr{Support can be enabled by using Homebrew or Macports}, 'unsupported compiler name';
 };
 
+subtest 'preprocessor parsing' => sub {
+  my $result = Alien::OpenMP::configure->version_from_preprocessor(<<'END_OF_CPP');
+#define _LP64 1
+#define _OPENMP 201811
+#define __GNUC_MINOR__ 2
+#define __GNUC_PATCHLEVEL__ 1
+#define __GNUC_STDC_INLINE__ 1
+#define __GNUC__ 4
+#define __GXX_ABI_VERSION 1002
+#define __USER_LABEL_PREFIX__ _
+#define __VERSION__ "Apple LLVM 12.0.5 (clang-1205.0.22.11)"
+#define __clang_version__ "12.0.5 (clang-1205.0.22.11)"
+
+END_OF_CPP
+  is_deeply $result, {openmp_version => '201811', version => '5.0'}, 'correct version';
+
+  my $unknown = Alien::OpenMP::configure->version_from_preprocessor(<<'END_OF_CPP');
+#define _LP64 1
+#define __GNUC_MINOR__ 2
+#define __GNUC_PATCHLEVEL__ 1
+#define __GNUC_STDC_INLINE__ 1
+#define __GNUC__ 4
+END_OF_CPP
+  is_deeply $unknown, {openmp_version => undef, version => 'unknown'}, 'unknown version';
+};
 
 done_testing;


### PR DESCRIPTION
This pull request adds the `openmp_version` method and a useful value for the `Alien::Base::version` method. Both provide access to the version of OpenMP available to the system to satisfy #21.

The format of the version is different is each case.

1. `openmp_version` - the value of `_OPENMP` i.e. `200505`
2. `version` - a decimal equivalent translated using this [table](https://github.com/jeffhammond/HPCInfo/blob/master/docs/Preprocessor-Macros.md#language-extensions-for-parallelism).

